### PR TITLE
Add save_settings call to persist toggle

### DIFF
--- a/terminus_persistence.py
+++ b/terminus_persistence.py
@@ -89,6 +89,7 @@ class ToggleTerminusPersistenceCommand(sublime_plugin.WindowCommand):
 
         # Toggle the setting
         settings.set("persistence_enabled", not current)
+        sublime.save_settings(SETTINGS_FILE)
 
         # Show status message
         status = "enabled" if not current else "disabled"


### PR DESCRIPTION
  ## Summary
  Fixes #7 - Toggle Persistence setting now persists correctly between sessions.

  ## Problem
  The "Toggle Persistence" menu item was changing state visually but not saving the setting. After restarting Sublime Text, the checkbox would revert to its previous state.

  ## Solution
  Added `sublime.save_settings(SETTINGS_FILE)` call after toggling the setting to ensure the preference is written to disk.

  ## Changes
  - Added `sublime.save_settings()` call in `ToggleTerminusPersistenceCommand.run()` method

  ## Testing
  ✅ Tested toggling persistence off with Terminus open → Terminus does not reopen on restart
  ✅ Tested toggling persistence on → Terminus reopens correctly on restart
  ✅ Tested that checkbox state persists correctly between sessions